### PR TITLE
Add onboarding submit handler with tests

### DIFF
--- a/onboarding-form/src/DynamicAccessForm.jsx
+++ b/onboarding-form/src/DynamicAccessForm.jsx
@@ -1,6 +1,7 @@
 // src/DynamicAccessForm.jsx
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
+import { handleOnboardingSubmit } from "./onboardingHandlers.js";
 
 // Alias the motion.div component so eslint recognizes it as used
 const MotionDiv = motion.div;
@@ -111,7 +112,7 @@ export default function DynamicAccessForm() {
                 </button>
               </form>
             ) : (
-              <form className="space-y-6">
+              <form onSubmit={handleOnboardingSubmit} className="space-y-6">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                   <div className="flex flex-col">
                     <label className="mb-1 text-sm font-medium">Full Name</label>

--- a/onboarding-form/src/onboardingHandlers.js
+++ b/onboarding-form/src/onboardingHandlers.js
@@ -1,0 +1,7 @@
+export function handleOnboardingSubmit(e) {
+  e.preventDefault();
+  const formData = e.target instanceof FormData ? e.target : new FormData(e.target);
+  const data = Object.fromEntries(formData.entries());
+  console.log("Onboarding form submitted:", data);
+  return data;
+}

--- a/onboarding-form/src/onboardingHandlers.test.js
+++ b/onboarding-form/src/onboardingHandlers.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleOnboardingSubmit } from './onboardingHandlers.js';
+
+test('handleOnboardingSubmit prevents default and logs data', () => {
+  let prevented = false;
+  const fd = new FormData();
+  fd.set('fullName', 'Alice');
+
+  const event = {
+    preventDefault: () => {
+      prevented = true;
+    },
+    target: fd,
+  };
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => logs.push(args);
+
+  const result = handleOnboardingSubmit(event);
+
+  console.log = originalLog;
+
+  assert.equal(prevented, true);
+  assert.deepEqual(result, { fullName: 'Alice' });
+  assert.deepEqual(logs[0], ['Onboarding form submitted:', { fullName: 'Alice' }]);
+});


### PR DESCRIPTION
## Summary
- wire onboarding form to a submit handler that prevents default and logs collected data
- export the handler for reuse
- test the handler's behavior with Node's test runner

## Testing
- `npm --prefix onboarding-form run lint`
- `node --test onboarding-form/src/onboardingHandlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68922ec18afc8320ad00a290601aa342